### PR TITLE
feat(lint): add support for pyright

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,10 @@ on:
       python-version:
         required: true
         type: string
+      type-checker:
+        type: string
+        required: false
+        default: mypy
       debian-version:
         required: false
         type: string
@@ -65,7 +69,7 @@ jobs:
         run: |
           ${{ inputs.build-tool }} run ruff format --check ${{ inputs.context-path }}
           ${{ inputs.build-tool }} run ruff check ${{ inputs.context-path }}
-          ${{ inputs.build-tool }} run mypy ${{ inputs.context-path }}
+          ${{ inputs.build-tool }} run ${{ inputs.type-checker }} ${{ inputs.context-path }}
 
   poetry-check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/self.yml
+++ b/.github/workflows/self.yml
@@ -3,8 +3,14 @@ on:
     branches: [ main ]
   pull_request: { }
 
+permissions:
+  contents: read
+
 jobs:
   required-meta:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: BlindfoldedSurgery/actions-meta/.github/workflows/required.yml@v1
 
   check:
@@ -15,6 +21,9 @@ jobs:
 
   bump:
     uses: BlindfoldedSurgery/actions-releases/.github/workflows/commitizen-bump.yml@v4
+    permissions:
+      contents: write
+      pull-requests: write
     with:
       build-tool: uv
       publish-major-tag: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Made the type checker tool configurable in the lint workflow, allowing users to specify a different type checker if desired.
  - Updated workflow permissions to be more explicit and granular for improved security management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->